### PR TITLE
Implement Unwrap Gift Logic

### DIFF
--- a/app/src/main/java/com/example/whiteelephantgiftexchange/data/PlayerData.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/data/PlayerData.kt
@@ -6,18 +6,18 @@ import com.example.whiteelephantgiftexchange.model.Player
 
 class PlayerData {
     val players = listOf<Player>(
-        Player("Grandma", gift = Gift(R.drawable.gloves),  giftUploaded = true),
-        Player("Grandpa", gift = Gift()),
-        Player("Mom", gift = Gift()),
-        Player("Joe", gift = Gift()),
-        Player("Lindsey", gift = Gift(R.drawable.gloves), giftUploaded = true),
-        Player("Georgia", gift = Gift()),
-        Player("Uncle Roger", gift = Gift()),
-        Player("Giselle", gift = Gift()),
-        Player("Ronald", gift = Gift()),
-        Player("Marie", gift = Gift(R.drawable.gloves), giftUploaded = true),
-        Player("Linda", gift = Gift(R.drawable.gloves), giftUploaded = true),
-        Player("Georgia", gift = Gift()),
-        Player("Uncle Ted", gift = Gift()),
+        Player("Grandma"),
+        Player("Grandpa", gift = Gift(R.drawable.gloves, false)),
+        Player("Mom"),
+        Player("Joe", gift = Gift(R.drawable.gloves, false)),
+        Player("Lindsey"),
+        Player("Georgia", gift = Gift(R.drawable.gloves)),
+        Player("Uncle Roger", gift = Gift(R.drawable.gloves)),
+        Player("Giselle", gift = Gift(R.drawable.gloves)),
+        Player("Ronald", gift = Gift(R.drawable.gloves, false)),
+        Player("Marie", gift = Gift(R.drawable.gloves)),
+        Player("Linda", gift = Gift(R.drawable.gloves)),
+        Player("Georgia", gift = Gift(R.drawable.gloves, false)),
+        Player("Uncle Ted"),
     )
 }

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/model/Gift.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/model/Gift.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import com.example.whiteelephantgiftexchange.R
 
 data class Gift(
-    @DrawableRes var image: Int = R.drawable.gift,
-    val isWrapped: Boolean = true,
+    @DrawableRes val image: Int,
+    var isWrapped: Boolean = true,
+    var giftReceiver: Player? = null
 )

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/model/Player.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/model/Player.kt
@@ -5,6 +5,6 @@ import com.example.whiteelephantgiftexchange.R
 
 class Player (
     val name: String = "",
-    val gift: Gift,
-    val giftUploaded: Boolean = false
+    val gift: Gift? = null,
+//    val giftUploaded: Boolean = false
 )

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameViewModel.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameViewModel.kt
@@ -11,7 +11,7 @@ class GameViewModel: ViewModel() {
     // GAME STATE
 
     // Backing property to avoid state updates from other classes
-    private val _uiState = MutableStateFlow(GameUiState(0)) // Private State
+    private val _uiState = MutableStateFlow(GameUiState()) // Private State
     val uiState: StateFlow<GameUiState> = _uiState.asStateFlow() // State the UI can safely consume
 
     var players: List<Player> = PlayerData().players

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
@@ -109,7 +109,7 @@ fun PlayersList(modifier: Modifier = Modifier) {
                             .padding(start = 48.dp)
                     ) {
 
-                        if (player.giftUploaded) {
+                        if (player.gift != null) {
                             Icon(
                                 painter = painterResource(id = R.drawable.done_24px),
                                 contentDescription = null,

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/theme/Type.kt
@@ -1,6 +1,7 @@
 package com.example.whiteelephantgiftexchange.ui.theme
 
 import androidx.compose.material3.Typography
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -14,21 +15,23 @@ val Typography = Typography(
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
+        fontWeight = FontWeight.Normal,
+        color = Color.DarkGray,
+        fontSize = 12.sp,
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
+
+    /* Other default text styles to override
+        titleLarge = TextStyle(
+            fontFamily = FontFamily.Default,
+            fontWeight = FontWeight.Normal,
+            fontSize = 22.sp,
+            lineHeight = 28.sp,
+            letterSpacing = 0.sp
+        ),
     */
 )

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="padding_xs">4dp</dimen>
     <dimen name="padding_small">8dp</dimen>
     <dimen name="padding_medium">16dp</dimen>
     <dimen name="padding_large">24dp</dimen>
     <dimen name="padding_xl">48dp</dimen>
+
+    <dimen name="image_size">100dp</dimen>
+    <dimen name="gift_card_size">175dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,29 @@
 <resources>
+    <!-- App & Navigation -->
     <string name="app_name">White Elephant Gift Exchange</string>
     <string name="back_button">Back</string>
 
+    <!-- Player Info -->
     <string name="view_players">View Players</string>
     <string name="players">Players</string>
     <string name="import_contacts">+ Import Contacts</string>
     <string name="add_gift">Add Gift 🎁</string>
 
+    <!-- Game Rules -->
     <string name="game_rules">Rules</string>
     <string name="game_rules_header">How to Play</string>
 
-    <string name="round_info">Round: 0</string>
+    <!-- Current Game Info -->
+    <string name="round_info">Round: </string>
+    <string name="missing_gift">Still waiting for %s to upload a gift.</string>
+
+    <!-- Gift Actions Info -->
+    <string name="alertbox_unwrap_gift_confirmation">Unwrap %s\'s gift?</string>
+    <string name="alertbox_steal_gift_confirmation">Steal This Gift?</string>
+    <string name="alertbox_missing_gift_error">Sorry, %s hasn\'t uploaded their gift yet.</string>
+
+    <!-- Gift Info -->
+    <string name="unwrapped_gift">Unwrapped Gift</string>
+    <string name="wrapped_gift">Wrapped Gift</string>
+    <string name="gift_from_message">From: %s</string>
 </resources>


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|  | Bug Fix |
|✔️| New Feature  |
|✔️| Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
**✨ New Feature Changes**
- Implemented unwrap gift logic.
    - If a player clicks on the gift card, an alert box asks the player to confirm they want to unwrap the clicked gift.
    - If the gift the player clicked on was already unwrapped, the alert box instead asks the player to confirm they want to steal it.
    - If the player hasn’t uploaded a gift their card displays an error message and clicking on the card will also display a message that tells the player to wait until the gift image is uploaded.

**⚙️ Refactor Changes**
- Tweaked text and image sizes, refactored out some additional dimension and string values to the /res folder.
- Tweaked Player and Gift models. A Player’s gift and a Gift’s giftReceiver values can be null

### To-Dos
---
- [ ] Implement steal gift logic (requires setting up state to tell application who the current player is, and what round we are in. Only the currently active player should have the option to unwrap or steal a gift.)
- [ ] Refactor state logic out to the GameViewModel file
- [ ] Test UI and game logic
