### PR TITLE
Debug Shuffle Players

### DIFF
--- a/app/src/main/java/com/example/whiteelephantgiftexchange/WhiteElephantScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/WhiteElephantScreen.kt
@@ -17,11 +17,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.whiteelephantgiftexchange.ui.GameViewModel
 import com.example.whiteelephantgiftexchange.ui.screens.GameScreen
 import com.example.whiteelephantgiftexchange.ui.screens.PlayersScreen
 import com.example.whiteelephantgiftexchange.ui.screens.RulesScreen
@@ -64,7 +66,8 @@ fun WhiteElephantGiftExchangeAppBar(
 @Composable
 fun WhiteElephantGiftExchangeApp(
     modifier: Modifier = Modifier,
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
+    gameViewModel: GameViewModel = viewModel(),
 ) {
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentScreen = WhiteElephantScreen.valueOf(
@@ -87,6 +90,7 @@ fun WhiteElephantGiftExchangeApp(
         ) {
             composable(route = WhiteElephantScreen.Images.name) {
                 GameScreen(
+                    gameViewModel = gameViewModel,
                     onRulesButtonClicked = { navController.navigate(WhiteElephantScreen.Rules.name) },
                     onPlayerButtonClicked = { navController.navigate(WhiteElephantScreen.Players.name) },
                 )
@@ -97,7 +101,7 @@ fun WhiteElephantGiftExchangeApp(
             }
 
             composable(route = WhiteElephantScreen.Players.name) {
-                PlayersScreen()
+                PlayersScreen(gameViewModel = gameViewModel)
             }
         }
     }

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameUiState.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameUiState.kt
@@ -1,8 +1,14 @@
 package com.example.whiteelephantgiftexchange.ui
 
+import com.example.whiteelephantgiftexchange.data.PlayerData
 import com.example.whiteelephantgiftexchange.model.Player
 
-class GameUiState(
+/**
+ * Data class that represents the game UI state
+ */
+
+data class GameUiState(
     val round: Int = 0,
-    val allPlayersReady: Boolean = false, // true when every player has uploaded a gift
+    var players: List<Player> = PlayerData().players,
+    val currentPlayer: Player = players[0],
 )

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameViewModel.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameViewModel.kt
@@ -1,29 +1,33 @@
 package com.example.whiteelephantgiftexchange.ui
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import com.example.whiteelephantgiftexchange.data.PlayerData
 import com.example.whiteelephantgiftexchange.model.Player
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class GameViewModel: ViewModel() {
     // GAME STATE
+    val allPlayersReady: Boolean = false // true when every player has uploaded a gift
 
     // Backing property to avoid state updates from other classes
     private val _uiState = MutableStateFlow(GameUiState()) // Private State
     val uiState: StateFlow<GameUiState> = _uiState.asStateFlow() // State the UI can safely consume
 
-    var players: List<Player> = PlayerData().players
-
     // GAME UTILITIES
-    fun resetGame() {
+    private fun resetGame() {
         // shuffle and wrap all gifts
-        _uiState.value = GameUiState(round = 0)
-
+        val players = PlayerData().players.shuffled()
+        _uiState.value = GameUiState()
     }
-    private fun shufflePlayers(): List<Player> {
-        return players.shuffled()
+    fun shufflePlayers() {
+        val shuffledPlayers = _uiState.value.players.shuffled()
+        _uiState.update { currentState ->
+            currentState.copy(players = shuffledPlayers, currentPlayer = shuffledPlayers[0])
+        }
     }
 
     // Game Util TODOs
@@ -36,4 +40,8 @@ class GameViewModel: ViewModel() {
         // fun onSteal() {}
         // fun onUnwrap() {}
         // fun onChooseGift() {}
+
+    init {
+        resetGame()
+    }
 }

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
@@ -48,6 +48,7 @@ fun GameScreen(
     modifier: Modifier = Modifier,
     gameViewModel: GameViewModel = viewModel(),
 ) {
+
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -58,8 +59,8 @@ fun GameScreen(
     ) {
         val gameUiState by gameViewModel.uiState.collectAsState()
 
-        Header(gameUiState, onRulesButtonClicked, onPlayerButtonClicked)
-        ImageGrid(players = gameViewModel.players)
+        Header(gameUiState, gameViewModel, onRulesButtonClicked, onPlayerButtonClicked)
+        ImageGrid(players = gameUiState.players)
     }
 }
 @OptIn(ExperimentalLayoutApi::class)
@@ -173,10 +174,13 @@ fun PlayerGiftCard(player: Player, modifier: Modifier = Modifier) {
 @Composable
 fun Header(
     gameUiState: GameUiState,
+    gameViewModel: GameViewModel,
     onRulesButtonClicked: () -> Unit,
     onPlayerButtonClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val startDialog = remember { mutableStateOf(false) }
+
     Row(modifier = modifier.padding(vertical = 16.dp)) {
         Button(
             onClick = onRulesButtonClicked,
@@ -195,17 +199,60 @@ fun Header(
                 .padding(start = 8.dp)
         ) {
             Text(
-                text = stringResource(id = R.string.view_players),
+                text = stringResource(id = R.string.players),
                 textAlign = TextAlign.Center
             )
         }
+
+        Button(
+            onClick = { startDialog.value = !startDialog.value },
+            modifier = modifier
+                .weight(1f)
+                .padding(start = 8.dp)
+        ) {
+            Text(
+                text = "Start",
+                textAlign = TextAlign.Center
+            )
+
+            if (gameViewModel.allPlayersReady && startDialog.value) {
+                AlertDialog(
+                    onDismissRequest = { startDialog.value = false },
+                    confirmButton = {
+                        TextButton(onClick = { startDialog.value = false }) {
+                            Text(text = "Yay!")
+                        }
+                    },
+                    text = { Text(text = "Starting Game...") }
+                )
+            } else if (!gameViewModel.allPlayersReady && startDialog.value) {
+                AlertDialog(
+                    onDismissRequest = { startDialog.value = false },
+                    confirmButton = {
+                        TextButton(onClick = { startDialog.value = false }) {
+                            Text(text = "Okay")
+                        }
+                    },
+                    text = { Text(text = "All Players Must Bring a Gift to Play!") }
+                )
+            }
+        }
     }
-    Text(
-        text = "${ stringResource(id = R.string.round_info) } ${gameUiState.round}",
-        textAlign = TextAlign.Center,
-        fontWeight = FontWeight.Bold,
-        modifier = modifier.padding(bottom = 16.dp)
-    )
+    Row {
+        Text(
+            text = "${stringResource(id = R.string.round_info)} ${gameUiState.round}",
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.Bold,
+            modifier = modifier.padding(bottom = 16.dp)
+        )
+
+        Text(
+            text = "Current Player: ${gameUiState.currentPlayer.name}",
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.Bold,
+            modifier = modifier.padding(start = 16.dp)
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
@@ -46,7 +46,7 @@ fun GameScreen(
     onRulesButtonClicked: () -> Unit,
     onPlayerButtonClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    gameViewModel: GameViewModel = viewModel(),
+    gameViewModel: GameViewModel,
 ) {
 
     Column(

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -25,21 +28,25 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.whiteelephantgiftexchange.R
 import com.example.whiteelephantgiftexchange.data.PlayerData
+import com.example.whiteelephantgiftexchange.ui.GameViewModel
 
 @Composable
-fun PlayersScreen(modifier: Modifier = Modifier) {
-    PlayersList()
+fun PlayersScreen(gameViewModel: GameViewModel = viewModel(), modifier: Modifier = Modifier) {
+    PlayersList(gameViewModel)
 }
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun PlayersList(modifier: Modifier = Modifier) {
+fun PlayersList(gameViewModel: GameViewModel, modifier: Modifier = Modifier) {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.fillMaxWidth()
     ) {
+        val gameUiState by gameViewModel.uiState.collectAsState()
+
         FlowRow(maxItemsInEachRow = 2, modifier = modifier.padding(16.dp)) {
             Button(
                 content = { Text(text = stringResource(R.string.import_contacts)) },
@@ -67,7 +74,7 @@ fun PlayersList(modifier: Modifier = Modifier) {
                         modifier = modifier.padding(end = 4.dp))
                     Text(text = "Shuffle Player Turns")
                 },
-                onClick = { /*TODO*/ },
+                onClick = { gameViewModel.shufflePlayers() },
                 modifier = modifier.weight(1f)
             )
         }
@@ -99,7 +106,7 @@ fun PlayersList(modifier: Modifier = Modifier) {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = modifier.fillMaxSize()
         ) {
-            PlayerData().players.forEachIndexed { index, player ->
+            gameUiState.players.forEachIndexed { index, player ->
                 item {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
@@ -34,7 +34,7 @@ import com.example.whiteelephantgiftexchange.data.PlayerData
 import com.example.whiteelephantgiftexchange.ui.GameViewModel
 
 @Composable
-fun PlayersScreen(gameViewModel: GameViewModel = viewModel(), modifier: Modifier = Modifier) {
+fun PlayersScreen(gameViewModel: GameViewModel, modifier: Modifier = Modifier) {
     PlayersList(gameViewModel)
 }
 @OptIn(ExperimentalLayoutApi::class)
@@ -150,5 +150,6 @@ fun PlayersList(gameViewModel: GameViewModel, modifier: Modifier = Modifier) {
 @Preview(showBackground = true)
 @Composable
 fun PlayersListPreview() {
-    PlayersScreen()
+    val gameViewModel: GameViewModel = viewModel()
+    PlayersScreen(gameViewModel)
 }


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|✔️| Bug Fix |
| | New Feature  |
| | Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
**🐛 Debug Changes**
- Lifted `viewModel` initialization from individual screens to parent `WhiteElephantScreen`, so that Game and Player screens can share state. Now "Current Player" on the Game screen renders the updated Player 1 after players turn order is shuffled on the Players Screen.