### PR TITLE
Start Round, Start Game, and Steal Gift Logic

### DIFF
--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameViewModel.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameViewModel.kt
@@ -2,7 +2,6 @@ package com.example.whiteelephantgiftexchange.ui
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
-import com.example.whiteelephantgiftexchange.data.PlayerData
 import com.example.whiteelephantgiftexchange.model.Player
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,17 +10,20 @@ import kotlinx.coroutines.flow.update
 
 class GameViewModel: ViewModel() {
     // GAME STATE
-    val allPlayersReady: Boolean = false // true when every player has uploaded a gift
+    var allPlayersReady: Boolean = false // true when every player has uploaded a gift
+    private var isFinalRound: Boolean = false // is true when all players have gone once, but the first player still needs to choose whether to keep or steal their gift.
 
-    // Backing property to avoid state updates from other classes
+    // Use a backing property to preserve private state from external modifications
     private val _uiState = MutableStateFlow(GameUiState()) // Private State
     val uiState: StateFlow<GameUiState> = _uiState.asStateFlow() // State the UI can safely consume
+
+    private val playerCount = _uiState.value.players.size
 
     // GAME UTILITIES
     private fun resetGame() {
         // shuffle and wrap all gifts
-        val players = PlayerData().players.shuffled()
-        _uiState.value = GameUiState()
+        _uiState.value = GameUiState(round = 0)
+        shufflePlayers()
     }
     fun shufflePlayers() {
         val shuffledPlayers = _uiState.value.players.shuffled()
@@ -31,15 +33,73 @@ class GameViewModel: ViewModel() {
     }
 
     // Game Util TODOs
-        // fun onTakeOrUploadImage() {} // Not sure this should be defined here
-        // fun onGameStart() {} ??
-        // fun onStartRound() {}
-        // fun onEndRound() {}
+    // fun onTakeOrUploadImage() {}
+    private fun onStartRound() {
+        _uiState.update { currentState ->
+            currentState.copy(round = currentState.round + 1)
+        }
+    }
+
+    // check if photos uploaded, set allPlayersReady to 'true'
+    // there should be as many photos of gifts as there are players
+    // each player should only bring 1 gift
+    // get all the Players' then filter out their gifts, then filter out any null gifts
+    fun onGameStart() {
+        val notReadyPlayers = _uiState.value.players.filter { it.gift == null }
+
+        if (notReadyPlayers.isEmpty()) {
+            allPlayersReady = true
+            onStartNewRound()
+        } else if (notReadyPlayers.isNotEmpty()) {
+            Log.d("ERROR", "All Players Must Upload a Gift to Play!")
+        } else {
+            Log.d("ERROR", "Unknown Error Occurred when attempting to start the game")
+        }
+    }
+    private fun onStartNewRound() {
+
+            // Update the current round int whether or not its the final round
+            _uiState.update { currentState ->
+                val nextPlayerIndex = currentState.round
+
+                // if it is NOT the final round update to the next player from the shuffled list of players
+                if (currentState.round <= playerCount && currentState.round != 0) {
+                    currentState.copy(round = currentState.round + 1, currentPlayer = currentState.players[nextPlayerIndex])
+                } else {
+                    // otherwise just set the current player to P1 and set finalRound to 'true'
+                    if (currentState.round !== 0) isFinalRound = true
+                    currentState.copy(round = currentState.round + 1, currentPlayer = currentState.players[0])
+                }
+            }
+        }
 
     // Round-Level TODOs
-        // fun onSteal() {}
-        // fun onUnwrap() {}
         // fun onChooseGift() {}
+
+        fun onStealGift(player: Player) {
+            // ❌ TODO: you can only be the receiver of one gift at a time
+
+            if ((player.gift?.giftReceiver != null) && (player.gift.giftReceiver != _uiState.value.currentPlayer)) {
+                val oldGiftReceiver: Player = player.gift.giftReceiver!!
+                player.gift.giftReceiver = _uiState.value.currentPlayer
+
+                // ❌ TODO: Some kind of alert to let players know the currentPlayer/round has changed
+                _uiState.update { currentState ->
+                    currentState.copy(currentPlayer = oldGiftReceiver)
+                }
+
+            } else if ((player.gift?.giftReceiver != null) && (player.gift.giftReceiver == _uiState.value.currentPlayer)) {
+                Log.d("ERROR", "You can't steal a gift that you've already claimed.")
+            } else {
+                Log.d("ERROR", "You can't steal an unopened gift.")
+            }
+        }
+
+        fun onUnwrapGift(player: Player) {
+            if (player.gift != null) player.gift.isWrapped = false
+            player.gift?.giftReceiver = _uiState.value.currentPlayer
+            onStartNewRound()
+        }
 
     init {
         resetGame()

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/PlayersScreen.kt
@@ -133,7 +133,7 @@ fun PlayersList(gameViewModel: GameViewModel, modifier: Modifier = Modifier) {
                                 .wrapContentHeight(align = Alignment.CenterVertically)
                         ) {
                             Text(
-                                text = "Player $index: ",
+                                text = "Player ${index + 1}: ",
                                 fontWeight = FontWeight.Bold,
                                 textAlign = TextAlign.End
                             )


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|✔️| Bug Fix |
|✔️| New Feature  |
| | Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
**✨ New Feature Changes**
**Start Game**
- If players have not uploaded an image of their gift, the game cannot begin. Clicking the “start” button will display an error message telling the users not all players are ready to begin.

	Alternatively, if all players have uploaded their gift the game begins, the Round is incremented by 1 and the current player is set to the player with the number 1.

**End Round/Start New Round**
- Unless it is the final round unwrapping a gift causes the round to end. Implemented this as part of the onUnwrapGift() function

**Steal Gift**
- Stealing a gift does not update the round, but updates the currentPlayer to the player who had their gift stolen. The road will only update after a new gift is unwrapped.

**Misc. Changes**
- Players can no longer unwrap or steal gifts until the game has started. Clicking on a card in the image grid before the game starts will display a message to the user saying as much.

### To-Dos
---
- [ ] Add explicit check to only allow a player to steal a gift if they haven’t already claimed a different gift
- [ ] Display a message to indicate illegal ‘steal’ actions were attempted, i.e. if a player tries to claim a second gift, or a gift they’ve already had during the current round.
- [ ] The start button can only be pressed if the round is set to 0 (indicating there is not already a game in progress). Might want to remove the button or change its text/functionality once the game has started (maybe update to “Restart” the game).