### PR TITLE
End Game Logic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,9 +15,6 @@
         android:theme="@style/Theme.WhiteElephantGiftExchange"
         tools:targetApi="31">
         <activity
-            android:name=".PlayersActivity"
-            android:exported="false" />
-        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/model/Player.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/model/Player.kt
@@ -6,5 +6,5 @@ import com.example.whiteelephantgiftexchange.R
 class Player (
     val name: String = "",
     val gift: Gift? = null,
-//    val giftUploaded: Boolean = false
+    var giftsReceivedThisRound: MutableList<Gift> = mutableListOf()
 )

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameUiState.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameUiState.kt
@@ -1,6 +1,7 @@
 package com.example.whiteelephantgiftexchange.ui
 
 import com.example.whiteelephantgiftexchange.data.PlayerData
+import com.example.whiteelephantgiftexchange.model.Gift
 import com.example.whiteelephantgiftexchange.model.Player
 
 /**
@@ -11,4 +12,5 @@ data class GameUiState(
     val round: Int = 0,
     var players: List<Player> = PlayerData().players,
     val currentPlayer: Player = players[0],
+    val gifts: List<Gift> = PlayerData().players.map { it.gift!! }
 )

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameUiState.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/GameUiState.kt
@@ -12,5 +12,5 @@ data class GameUiState(
     val round: Int = 0,
     var players: List<Player> = PlayerData().players,
     val currentPlayer: Player = players[0],
-    val gifts: List<Gift> = PlayerData().players.map { it.gift!! }
+    val gifts: List<Gift> = players.map { it.gift!! }
 )

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
@@ -1,5 +1,6 @@
 package com.example.whiteelephantgiftexchange.ui.screens
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -91,6 +92,7 @@ fun PlayerGiftCard(
 ) {
     val openAlertDialog = remember { mutableStateOf(false) }
     var showStealGiftErrorDialog = remember { mutableStateOf(false) }
+    var showGameOverDialog = remember { mutableStateOf(false) }
 
     Card(
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
@@ -125,7 +127,7 @@ fun PlayerGiftCard(
                         }
                     )
 
-                } else if (gameUiState.round > 0 && gameUiState.round <= gameUiState.players.size) {
+                } else if (gameUiState.round > 0 && gameUiState.round <= gameUiState.players.size + 1) {
                     AlertDialog(
                         text = { Text(text = alertDialogText) },
                         onDismissRequest = { openAlertDialog.value = false },
@@ -139,8 +141,11 @@ fun PlayerGiftCard(
                                             gameViewModel.onUnwrapGift(player = player)
                                         } else {
                                             val stealResult = gameViewModel.onStealGift(player = player)
+
                                             if (stealResult == R.string.gift_claimed_error) {
                                                 showStealGiftErrorDialog.value = true
+                                            } else if (stealResult == R.string.game_over_msg) {
+                                                showGameOverDialog.value = true
                                             }
                                         }
 
@@ -168,6 +173,22 @@ fun PlayerGiftCard(
                             showStealGiftErrorDialog.value = false
                         }) { Text(stringResource(R.string.try_again_text)) }
                     }
+                )
+            }
+
+            if (showGameOverDialog.value) {
+                AlertDialog(
+                    text = { Text(text = stringResource(id = R.string.game_over_msg)) },
+                    onDismissRequest = {
+                        showGameOverDialog.value = false
+                   },
+                confirmButton = {},
+                dismissButton = {
+                    TextButton(onClick = {
+                        showGameOverDialog.value = false
+                        gameViewModel.endGame()
+                    }) { Text(stringResource(R.string.play_again_text)) }
+                }
                 )
             }
 
@@ -293,6 +314,13 @@ fun Header(
 
             Text(
                 text = stringResource(R.string.current_player, gameUiState.currentPlayer.name),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                modifier = modifier.padding(start = 16.dp)
+            )
+
+            Text(
+                text = "Final Round: ${gameViewModel.isFinalRound}",
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold,
                 modifier = modifier.padding(start = 16.dp)

--- a/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
+++ b/app/src/main/java/com/example/whiteelephantgiftexchange/ui/screens/GameScreen.kt
@@ -1,6 +1,5 @@
 package com.example.whiteelephantgiftexchange.ui.screens
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -91,6 +90,7 @@ fun PlayerGiftCard(
     gameUiState: GameUiState
 ) {
     val openAlertDialog = remember { mutableStateOf(false) }
+    var showStealGiftErrorDialog = remember { mutableStateOf(false) }
 
     Card(
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
@@ -105,7 +105,6 @@ fun PlayerGiftCard(
     ) {
         // On card click, An Alert Box should have the user confirm they want to unwrap the selected gift
         Box(contentAlignment = Alignment.Center, modifier = modifier.fillMaxSize()) {
-
             val alertDialogText = when {
                 player.gift == null -> stringResource(id = R.string.alertbox_missing_gift_error, player.name)
                 (player.gift != null && player.gift.isWrapped) -> stringResource(id = R.string.alertbox_unwrap_gift_confirmation, player.name)
@@ -113,18 +112,19 @@ fun PlayerGiftCard(
             }
 
             if (openAlertDialog.value) {
-                Log.d("ERROR", "${gameUiState.round}")
                 if (gameUiState.round <= 0) {
+
                     AlertDialog(
-                        text = { Text(text = "Start a game to view other player's gifts") },
+                        text = { Text(text = stringResource(R.string.start_a_game_msg)) },
                         onDismissRequest = { openAlertDialog.value = false },
                         confirmButton = {
                             TextButton(
                                 onClick = { openAlertDialog.value = false }) {
-                                Text("Okay")
+                                Text(stringResource(id = R.string.okay_text))
                             }
                         }
                     )
+
                 } else if (gameUiState.round > 0 && gameUiState.round <= gameUiState.players.size) {
                     AlertDialog(
                         text = { Text(text = alertDialogText) },
@@ -138,23 +138,39 @@ fun PlayerGiftCard(
                                         if (player.gift.isWrapped) {
                                             gameViewModel.onUnwrapGift(player = player)
                                         } else {
-                                            // Steal gift logic
-                                            gameViewModel.onStealGift(player = player)
+                                            val stealResult = gameViewModel.onStealGift(player = player)
+                                            if (stealResult == R.string.gift_claimed_error) {
+                                                showStealGiftErrorDialog.value = true
+                                            }
                                         }
 
                                     }) {
-                                    Text("Confirm")
+                                    Text(stringResource(R.string.confirm_btn_text))
                                 }
                             }
                         },
                         dismissButton = {
                             TextButton(onClick = {
                                 openAlertDialog.value = false
-                            }) { Text("Exit") }
+                            }) { Text(stringResource(R.string.exit_txt)) }
                         }
                     )
                 }
             }
+
+            if (showStealGiftErrorDialog.value) {
+                AlertDialog(
+                    text = { Text(text = stringResource(id = R.string.gift_claimed_error)) },
+                    onDismissRequest = { showStealGiftErrorDialog.value = false },
+                    confirmButton = {},
+                    dismissButton = {
+                        TextButton(onClick = {
+                            showStealGiftErrorDialog.value = false
+                        }) { Text(stringResource(R.string.try_again_text)) }
+                    }
+                )
+            }
+
 
             if (player.gift?.image == null)  {
                 Text(
@@ -176,7 +192,7 @@ fun PlayerGiftCard(
                     )
                     if (player.gift.giftReceiver?.name != null) {
                         Text(
-                            text = "Claimed by: ${player.gift.giftReceiver?.name}", // fix this to prevent players from 'receiving' more than one gift at a time
+                            text = stringResource(R.string.claimed_by_msg, player.gift.giftReceiver!!.name), // fix this to prevent players from 'receiving' more than one gift at a time
                             textAlign = TextAlign.Start,
                             style = MaterialTheme.typography.labelSmall,
                             modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.padding_small))
@@ -245,7 +261,7 @@ fun Header(
                 .padding(start = 8.dp)
         ) {
             Text(
-                text = "Start",
+                text = stringResource(R.string.start_text),
                 textAlign = TextAlign.Center
             )
 
@@ -254,10 +270,13 @@ fun Header(
                     onDismissRequest = { startDialog.value = false },
                     confirmButton = {
                         TextButton(onClick = { startDialog.value = false }) {
-                            Text(text =  "Okay")
+                            Text(text = stringResource(R.string.okay_text))
                         }
                     },
-                    text = { Text(text = if (gameViewModel.allPlayersReady) "Starting New Game...the first player is ${gameUiState.currentPlayer.name}" else "All Players Must Bring a Gift to Play! Make sure everyone has brought a gift and try again.") }
+                    text = { Text(text = if (gameViewModel.allPlayersReady) stringResource(R.string.starting_new_game_msg, gameUiState.currentPlayer.name) else stringResource(
+                        R.string.start_new_game_error_msg
+                    )
+                    ) }
                 )
             }
         }
@@ -273,12 +292,13 @@ fun Header(
             )
 
             Text(
-                text = "Current Player: ${gameUiState.currentPlayer.name}",
+                text = stringResource(R.string.current_player, gameUiState.currentPlayer.name),
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold,
                 modifier = modifier.padding(start = 16.dp)
             )
         }
+
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_name">White Elephant Gift Exchange</string>
     <string name="back_button">Back</string>
 
-    <!-- Player Info -->
+    <!-- Players Screen Info -->
     <string name="view_players">View Players</string>
     <string name="players">Players</string>
     <string name="import_contacts">+ Import Contacts</string>
@@ -14,8 +14,10 @@
     <string name="game_rules_header">How to Play</string>
 
     <!-- Current Game Info -->
+    <string name="starting_new_game_msg">Starting New Game...the first player is %s</string>
     <string name="round_info">Round: </string>
     <string name="missing_gift">Still waiting for %s to upload a gift.</string>
+    <string name="current_player">Current Player: %s</string>
 
     <!-- Gift Actions Info -->
     <string name="alertbox_unwrap_gift_confirmation">Unwrap %s\'s gift?</string>
@@ -26,4 +28,19 @@
     <string name="unwrapped_gift">Unwrapped Gift</string>
     <string name="wrapped_gift">Wrapped Gift</string>
     <string name="gift_from_message">From: %s</string>
+    <string name="claimed_by_msg">Claimed by: %s</string>
+
+    <!-- Button Text -->
+    <string name="try_again_text">Try again</string>
+    <string name="start_text">Start</string>
+    <string name="okay_text">Okay</string>
+    <string name="confirm_btn_text">Confirm</string>
+    <string name="exit_txt">Exit</string>
+
+    <!-- Error Strings -->
+    <string name="start_new_game_error_msg">All Players Must Bring a Gift to Play! Make sure everyone has brought a gift and try again.</string>
+    <string name="current_gift_error">This is your current gift.</string>
+    <string name="steal_unopened_gift_error">You can\'t steal an unopened gift.</string>
+    <string name="start_a_game_msg">Start a game to view other player\'s gifts</string>
+    <string name="gift_claimed_error">You can\'t steal a gift that you\'ve already claimed during this round.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,7 @@
     <string name="steal_unopened_gift_error">You can\'t steal an unopened gift.</string>
     <string name="start_a_game_msg">Start a game to view other player\'s gifts</string>
     <string name="gift_claimed_error">You can\'t steal a gift that you\'ve already claimed during this round.</string>
+    <string name="game_over_msg">Game Over! Hope you enjoy your gifts</string>
+    <string name="play_again_text">Play Again</string>
+    <string name="cant_open_missing_gift">You cant open a missing gift</string>
 </resources>


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|  | Bug Fix |
|✔️| New Feature  |
|✔️| Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
**⚙️ Refactor Changes**
- Implemented logic to prevent players from claiming a gift more than once per round. 
  - Added a list of `giftsReceivedThisRound` to each Player to track these. 
  - Updated the `onStartNewRound()` function to clear the list of all giftsReceivedThisRound (except the player's currently claimed gift).
  - Refactored PlayerCard composable to call `onStealGift()`, which now returns an error if the gift was already received during the current round. If an error is returned instead of a successful steal, an alert dialog displays the error to the player. 

**✨ New Feature Changes**
- Added Game Over and Reset/Start New Game logic. This required not only tracking when the current player has looped back to Player 1, but also tweaking the game logic to allow a final round that exceeds the number of players (so the final player can choose whether to steal a gift).
- Once the game is over, a Game Over dialog displays and allows the option to start a reset the game. 